### PR TITLE
fix: wrong time zones returned by strptime

### DIFF
--- a/R/grabMzmlFunctions.R
+++ b/R/grabMzmlFunctions.R
@@ -283,7 +283,8 @@ grabMzmlMetadata <- function(xml_data){
   time_node <- xml2::xml_find_first(xml_data, xpath = "//d1:run")
   time_val <- xml2::xml_attr(time_node, "startTimeStamp")
   if(!is.na(time_val)){
-    time_stamp <- as.POSIXct(strptime(time_val, "%Y-%m-%dT%H:%M:%SZ"))
+    time_val <- sub("Z$", "+0000", time_val)
+    time_stamp <- as.POSIXct(strptime(time_val, "%Y-%m-%dT%H:%M:%S%z", tz="UTC"))
   } else {
     time_stamp <- as.POSIXct(NA)
   }

--- a/tests/testthat/test_chroms.R
+++ b/tests/testthat/test_chroms.R
@@ -21,3 +21,8 @@ test_that("warning thrown when requesting chroms from mzXML", {
   expect_warning(grabMSdata(mzXML_filenames[2], grab_what = "chroms"),
                  regexp = "grab_what = 'chroms' not available for mzXML documents")
 })
+
+test_that("time stamp is correct", {
+  expect_identical(msdata_MRM_everything$metadata$timestamp,
+                   as.POSIXct("2022-08-11 12:34:56",tz="UTC"))
+})


### PR DESCRIPTION
Hi William, 

I noticed that the current way of parsing of the startTimeStamp does not correctly interpret the time zone because strptime does not correctly interpret the "Z" at the end of the time zone. For example in your test file `wk_chrom.mzML`, the time stamp is `2022-08-11T12:34:56Z`. 

In the current version of `grabMzmlMetadata` this is parsed as:
```
time_val <- "2022-08-11T12:34:56Z"
time_stamp <- as.POSIXct(strptime(time_val, "%Y-%m-%dT%H:%M:%SZ"))
```
which returns (on my computer) "2022-08-11 12:34:56 EDT" because `strptime` does not seem to recognize the UTC time zone indicated by 'Z'.

I tried to fix this by replacing "Z" with a timezone that strptime can understand, "+0000". Alternatively, lubridate recognizes the timezone correctly. For example, `lubridate::ymd_hms("2022-08-11T12:34:56Z")` correctly returns "2022-08-11 12:34:56 UTC". However, this would add an additional dependency which I think you would probably prefer to avoid.

best,
Ethan